### PR TITLE
Improve route summary display

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <title>Vite + React</title>
   </head>
   <body>

--- a/app/src/assets/css/custom.css
+++ b/app/src/assets/css/custom.css
@@ -117,6 +117,8 @@
 html, body, #root {
   height: 100%;
   margin: 0;
+  font-family: 'Inter', Arial, sans-serif;
+  background-color: #f7f8fa;
 }
 .container-fluid.full-vh {
   height: 100vh;
@@ -128,8 +130,24 @@ html, body, #root {
 .left-panel {
   height: 100%;
   overflow-y: auto;
+  background-color: #ffffff;
+  border-right: 1px solid #ddd;
 }
 .map-container {
   height: 100%;
   padding: 0; /* para que el mapa no herede padding */
+}
+
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  transition: opacity 0.3s ease;
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,11 +1,11 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- track deliveries data in a ref
- show marker order and color in the route summary panel
- display spinner and success/error messages during optimization
- widen the summary panel and organize stops by route
- show full-screen spinner overlay while optimizing
- list distance and duration per route in the summary
- load Inter font and apply new styles for a cleaner look

## Testing
- `npm run lint --prefix app` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861d550a26883229844d102d9403f3e